### PR TITLE
Print errors with "hPutStrLn stderr".

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -6,6 +6,7 @@ import           Data.Text.IO        (readFile, writeFile)
 import           Prelude             hiding (readFile, writeFile)
 import           System.Environment  (getArgs)
 import           System.Exit
+import           System.IO           (hPutStrLn, stderr)
 import           Update.Nix.FetchGit
 import           Update.Nix.FetchGit.Utils
 import           Update.Nix.FetchGit.Warning
@@ -34,5 +35,5 @@ main =
 
 printErrorAndExit :: Warning -> IO ()
 printErrorAndExit e = do
-  print (formatWarning e)
+  hPutStrLn stderr (formatWarning e)
   exitWith (ExitFailure 1)


### PR DESCRIPTION
This fixes issue #4, which was caused because "print" modifies strings
using "show" before printing them.  Also, this makes the errors get
printed to the standard error output, which is the convention.
