### PR TITLE
Add support for builtins.fetchGit

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is a command-line utility for updating `fetchgit`, `fetchgitPrivate`, and `
 When you run `update-nix-fetchgit` on a file, it will:
 
 - Read the file and parse it as a Nix expression.
-- Find all Git fetches (calls to `fetchgit`, `fetchgitPrivate`, or `fetchFromGitHub`).
+- Find all Git fetches (calls to `fetchgit`, `fetchgitPrivate`, `fetchFromGitHub` or `fetchFromGitLab`).
 - Run [`nix-prefetch-git`](https://github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/fetchgit/nix-prefetch-git) to get information about the latest HEAD commit of each repository.
 - Update the corresponding rev, sha256, and version attributes for each repository.
 - Overwrite the original input file.

--- a/src/Update/Nix/FetchGit.hs
+++ b/src/Update/Nix/FetchGit.hs
@@ -78,6 +78,11 @@ exprToFetchTree = para $ \e subs -> case e of
     | extractFuncName function == Just "fetchFromGitHub"
     -> FetchNode <$> extractFetchFromGitHubArgs bindings
 
+  -- And to fetchFromGitLab.
+  AnnE _ (NBinary NApp function (AnnE _ (NSet _rec bindings)))
+    | extractFuncName function == Just "fetchFromGitLab"
+    -> FetchNode <$> extractFetchFromGitLabArgs bindings
+
   -- If it is an attribute set, find any attributes in it that we
   -- might want to update.
   AnnE _ (NSet _rec bindings)
@@ -97,6 +102,14 @@ extractFetchGitArgs bindings =
 extractFetchFromGitHubArgs :: [Binding NExprLoc] -> Either Warning FetchGitArgs
 extractFetchFromGitHubArgs bindings =
     FetchGitArgs <$> (GitHub <$> (exprText =<< extractAttr "owner" bindings)
+                             <*> (exprText =<< extractAttr "repo" bindings))
+                 <*> extractAttr "rev" bindings
+                 <*> extractAttr "sha256" bindings
+
+-- | Extract a 'FetchGitArgs' from the attrset being passed to fetchFromGitLab.
+extractFetchFromGitLabArgs :: [Binding NExprLoc] -> Either Warning FetchGitArgs
+extractFetchFromGitLabArgs bindings =
+    FetchGitArgs <$> (GitLab <$> (exprText =<< extractAttr "owner" bindings)
                              <*> (exprText =<< extractAttr "repo" bindings))
                  <*> extractAttr "rev" bindings
                  <*> extractAttr "sha256" bindings

--- a/src/Update/Nix/FetchGit/Types.hs
+++ b/src/Update/Nix/FetchGit/Types.hs
@@ -26,9 +26,10 @@ data FetchTree fetchInfo = Node { nodeVersionExpr :: Maybe NExprLoc
 
 -- | Represents the arugments to a call to fetchgit, fetchFromGitHub
 --   or fetchFromGitLab as parsed from a .nix file.
+--   sha256Expr will be empty on calls to builtins.fetchGit.
 data FetchGitArgs = FetchGitArgs { repoLocation :: RepoLocation
                                  , revExpr      :: NExprLoc
-                                 , sha256Expr   :: NExprLoc
+                                 , sha256Expr   :: Maybe NExprLoc
                                  }
   deriving (Show, Data)
 

--- a/src/Update/Nix/FetchGit/Types.hs
+++ b/src/Update/Nix/FetchGit/Types.hs
@@ -24,7 +24,7 @@ data FetchTree fetchInfo = Node { nodeVersionExpr :: Maybe NExprLoc
                          | FetchNode fetchInfo
   deriving (Show, Data, Functor, Foldable, Traversable)
 
--- | Represents the arugments to a call to fetchgit, fetchFromGitHub
+-- | Represents the arguments to a call to fetchgit, fetchFromGitHub
 --   or fetchFromGitLab as parsed from a .nix file.
 --   sha256Expr will be empty on calls to builtins.fetchGit.
 data FetchGitArgs = FetchGitArgs { repoLocation :: RepoLocation

--- a/src/Update/Nix/FetchGit/Types.hs
+++ b/src/Update/Nix/FetchGit/Types.hs
@@ -24,8 +24,8 @@ data FetchTree fetchInfo = Node { nodeVersionExpr :: Maybe NExprLoc
                          | FetchNode fetchInfo
   deriving (Show, Data, Functor, Foldable, Traversable)
 
--- | Represents the arugments to a call to fetchgit or fetchFromGitHub
---   as parsed from a .nix file.
+-- | Represents the arugments to a call to fetchgit, fetchFromGitHub
+--   or fetchFromGitLab as parsed from a .nix file.
 data FetchGitArgs = FetchGitArgs { repoLocation :: RepoLocation
                                  , revExpr      :: NExprLoc
                                  , sha256Expr   :: NExprLoc
@@ -44,6 +44,9 @@ data FetchGitLatestInfo = FetchGitLatestInfo { originalInfo :: FetchGitArgs
 -- | A repo is either specified by URL or by Github owner/repo.
 data RepoLocation = URL Text
                   | GitHub { owner :: Text
+                           , repo  :: Text
+                           }
+                  | GitLab { owner :: Text
                            , repo  :: Text
                            }
   deriving (Show, Data)

--- a/src/Update/Nix/FetchGit/Utils.hs
+++ b/src/Update/Nix/FetchGit/Utils.hs
@@ -48,6 +48,7 @@ extractUrlString :: RepoLocation -> Text
 extractUrlString = \case
   URL u -> u
   GitHub o r -> "https://github.com/" <> o <> "/" <> r <> ".git"
+  GitLab o r -> "https://gitlab.com/" <> o <> "/" <> r <> ".git"
 
 -- Add double quotes around a string so it can be inserted into a Nix
 -- file as a string literal.


### PR DESCRIPTION
This is similar to `fetchgit` but is resolved at evaluation time and doesn't include a `sha256` attribute.

Fixes #20. Depends on #21.