### PR TITLE
Remove unused dependencies data-fix and trifecta

### DIFF
--- a/update-nix-fetchgit.cabal
+++ b/update-nix-fetchgit.cabal
@@ -29,7 +29,6 @@ library
                      , aeson >= 0.9
                      , async >= 2.1
                      , bytestring >= 0.10
-                     , data-fix >= 0.0
                      , errors >= 2.1
                      , hnix >= 0.8
                      , prettyprinter
@@ -37,7 +36,6 @@ library
                      , text >= 1.2
                      , time >= 1.5
                      , transformers >= 0.4
-                     , trifecta >= 1.6
                      , uniplate >= 1.6
                      , utf8-string >= 1.0
   default-language:    Haskell2010


### PR DESCRIPTION
It seems like the dependencies data-fix and trifecta are not actually
used anywhere in the source for update-nix-fetchgit. Unless I have
missed something, they should probably be removed, if only to decrease
build times.

Additionally, the dependency on trifecta, at least for me, causes
dependency resolution to fail when trying to build the project using
Nix.