### PR TITLE
Remove ghc 8.4 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        ghc: ['8.10.1', '8.8.3', '8.6.5', '8.4.4']
+        ghc: ['8.10.2', '8.8.4', '8.6.5']
         cabal: ['3.0']
         os: [ubuntu-latest]
       fail-fast: false


### PR DESCRIPTION
Minor version bumps on other versions