### PR TITLE
Pass `--heads --tags` to `git ls-remote` to avoid fetching remote refs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## WIP
 
+- Pass `--heads --tags` to `git ls-remote` to avoid fetching remote
+  refs. Don't pass when the revision begins with `refs`
+
 ## [0.2.4] - 2020-11-11
 
 - Add --dry-run option

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## WIP
 
+## [0.2.5] - 2020-11-14
+
 - Pass `--heads --tags` to `git ls-remote` to avoid fetching remote
   refs. Don't pass when the revision begins with `refs`
 

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name: update-nix-fetchgit
-version: "0.2.4"
+version: "0.2.5"
 synopsis: A program to update fetchgit values in Nix expressions
 description: |
   This command-line utility is meant to be used by people maintaining Nix

--- a/update-nix-fetchgit.cabal
+++ b/update-nix-fetchgit.cabal
@@ -5,7 +5,7 @@ cabal-version: 1.12
 -- see: https://github.com/sol/hpack
 
 name:           update-nix-fetchgit
-version:        0.2.4
+version:        0.2.5
 synopsis:       A program to update fetchgit values in Nix expressions
 description:    This command-line utility is meant to be used by people maintaining Nix
                 expressions that fetch files from Git repositories. It automates the process


### PR DESCRIPTION
Don't pass when the revision begins with `refs`