### PR TITLE
Adjust for hnix >= 0.13

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -127,6 +127,3 @@ instance Read Regex where
 instance ParseField Regex where
   metavar _ = "REGEX"
   readField = eitherReader makeRegexM
-
-instance (e ~ String) => MonadFail (Either e) where
-  fail = Left

--- a/src/Nix/Match/Typed.hs
+++ b/src/Nix/Match/Typed.hs
@@ -201,8 +201,8 @@ typedMatcherGen
   -> Q (([T.Text], [T.Text]), Exp)
 typedMatcherGen parseNix collect add strip s = do
   expr <- case parseNix (T.pack s) of
-    Failure err -> fail $ show err
-    Success e   -> pure e
+    Left err -> fail $ show err
+    Right e  -> pure e
   let (opt, req) = collect expr
       optT       = symbolList opt
       reqT       = symbolList req

--- a/src/Update/Nix/FetchGit/Utils.hs
+++ b/src/Update/Nix/FetchGit/Utils.hs
@@ -48,13 +48,13 @@ import           Update.Span
 
 ourParseNixText :: Text -> Either Warning NExprLoc
 ourParseNixText t = case parseNixTextLoc t of
-  Failure parseError -> Left (CouldNotParseInput (tShow parseError))
-  Success expr       -> pure expr
+  Left parseError -> Left (CouldNotParseInput (tShow parseError))
+  Right expr      -> pure expr
 
 ourParseNixFile :: FilePath -> M NExprLoc
 ourParseNixFile f = liftIO (parseNixFileLoc f) >>= \case
-  Failure parseError -> refute1 (CouldNotParseInput (tShow parseError))
-  Success expr       -> pure expr
+  Left parseError -> refute1 (CouldNotParseInput (tShow parseError))
+  Right expr      -> pure expr
 
 -- | Get the url from either a nix expression for the url or a repo and owner
 -- expression.

--- a/update-nix-fetchgit.cabal
+++ b/update-nix-fetchgit.cabal
@@ -1,6 +1,6 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.34.2.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 
@@ -76,7 +76,30 @@ library
       Paths_update_nix_fetchgit
   hs-source-dirs:
       src
-  default-extensions: DataKinds DefaultSignatures DeriveAnyClass DeriveDataTypeable DeriveGeneric DerivingStrategies FlexibleContexts FlexibleInstances GADTs LambdaCase MultiParamTypeClasses OverloadedStrings PolyKinds RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TemplateHaskellQuotes TupleSections TypeApplications TypeFamilies TypeOperators ViewPatterns
+  default-extensions:
+      DataKinds
+      DefaultSignatures
+      DeriveAnyClass
+      DeriveDataTypeable
+      DeriveGeneric
+      DerivingStrategies
+      FlexibleContexts
+      FlexibleInstances
+      GADTs
+      LambdaCase
+      MultiParamTypeClasses
+      OverloadedStrings
+      PolyKinds
+      RankNTypes
+      RecordWildCards
+      ScopedTypeVariables
+      StandaloneDeriving
+      TemplateHaskellQuotes
+      TupleSections
+      TypeApplications
+      TypeFamilies
+      TypeOperators
+      ViewPatterns
   ghc-options: -Wall
   build-depends:
       aeson >=0.9
@@ -104,7 +127,30 @@ executable update-nix-fetchgit
       Paths_update_nix_fetchgit
   hs-source-dirs:
       app
-  default-extensions: DataKinds DefaultSignatures DeriveAnyClass DeriveDataTypeable DeriveGeneric DerivingStrategies FlexibleContexts FlexibleInstances GADTs LambdaCase MultiParamTypeClasses OverloadedStrings PolyKinds RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TemplateHaskellQuotes TupleSections TypeApplications TypeFamilies TypeOperators ViewPatterns
+  default-extensions:
+      DataKinds
+      DefaultSignatures
+      DeriveAnyClass
+      DeriveDataTypeable
+      DeriveGeneric
+      DerivingStrategies
+      FlexibleContexts
+      FlexibleInstances
+      GADTs
+      LambdaCase
+      MultiParamTypeClasses
+      OverloadedStrings
+      PolyKinds
+      RankNTypes
+      RecordWildCards
+      ScopedTypeVariables
+      StandaloneDeriving
+      TemplateHaskellQuotes
+      TupleSections
+      TypeApplications
+      TypeFamilies
+      TypeOperators
+      ViewPatterns
   ghc-options: -Wall -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       base >=4.13
@@ -124,7 +170,30 @@ test-suite update-nix-fetchgit-samples
       Paths_update_nix_fetchgit
   hs-source-dirs:
       tests
-  default-extensions: DataKinds DefaultSignatures DeriveAnyClass DeriveDataTypeable DeriveGeneric DerivingStrategies FlexibleContexts FlexibleInstances GADTs LambdaCase MultiParamTypeClasses OverloadedStrings PolyKinds RankNTypes RecordWildCards ScopedTypeVariables StandaloneDeriving TemplateHaskellQuotes TupleSections TypeApplications TypeFamilies TypeOperators ViewPatterns
+  default-extensions:
+      DataKinds
+      DefaultSignatures
+      DeriveAnyClass
+      DeriveDataTypeable
+      DeriveGeneric
+      DerivingStrategies
+      FlexibleContexts
+      FlexibleInstances
+      GADTs
+      LambdaCase
+      MultiParamTypeClasses
+      OverloadedStrings
+      PolyKinds
+      RankNTypes
+      RecordWildCards
+      ScopedTypeVariables
+      StandaloneDeriving
+      TemplateHaskellQuotes
+      TupleSections
+      TypeApplications
+      TypeFamilies
+      TypeOperators
+      ViewPatterns
   ghc-options: -Wall
   build-depends:
       base >=4.7 && <5


### PR DESCRIPTION
* Result is now an alias to Either
* hnix somehow propagates `instance (e ~ String) => MonadFail (Either e)`
  from relude, so the instance is no longer necessary.

Resolves #62.